### PR TITLE
feat: basic slack config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+package-lock.json
+node_modules/

--- a/elex-testing-results/index.js
+++ b/elex-testing-results/index.js
@@ -1,0 +1,22 @@
+const { WebClient } = require('@slack/web-api');
+require('dotenv').config()
+
+//* ID of the channel you want to send the message to
+//! Change this to the main elex channel when ready
+const channelId = "C06TYKYGGM9";
+const web = new WebClient(process.env.SLACK_TOKEN);
+
+(async () => {
+    try {
+        await web.chat.postMessage({
+            channel: channelId,
+            //! TODO: replace with data from API
+            text: "Hello from the script"
+        });
+
+        console.log("Message has been posted");
+    }
+    catch (error) {
+        console.error(error);
+    }
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "elections-bots",
+  "version": "1.0.0",
+  "description": "This repo contains election slackbots",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@slack/web-api": "^7.0.2",
+    "dotenv": "^16.4.5"
+  }
+}


### PR DESCRIPTION
## Describe your changes
This PR adds the basic configuration to send a sample message to the #elex-bots-test channel using slack api.

## Issue ticket number and link
[Issue-165
](https://github.com/nprapps/elections24-primaries/issues/165)

## Testing Steps
- Run `npm instal`
- Make sure to create a `.env` file and add the `SLACK_TOKEN`
- Run `node index.js` from the `elex-testing-results` folder
- In the elex-bots-test, you will see a sample message