### PR TITLE
feat: basic config to write to sheets

### DIFF
--- a/elex-testing-results/sheets.js
+++ b/elex-testing-results/sheets.js
@@ -1,0 +1,34 @@
+require('dotenv').config()
+var { google } = require("googleapis");
+var login = require("@nprapps/google-login");
+
+const spreadsheetId = process.env.SHEETS_ID
+const range = "Sheet1!A4:Z10000"
+const valueInputOption = "USER_ENTERED"
+
+//! Replace them with values from AP API
+const values = [
+    ["Wheel", "$20.50", "4", "3/1/2016"],
+    ["Door", "$15", "2", "3/15/2016"],
+    ["Engine", "$100", "1", "3/20/2016"],
+]
+
+async function writeTestData(auth) {
+    var auth = login.getClient();
+    const sheets = google.sheets({ version: 'v4', auth });
+
+    try {
+        const result = await sheets.spreadsheets.values.append({
+            spreadsheetId,
+            range,
+            valueInputOption,
+            resource: { values }
+        });
+        console.log('%d cells updated.', result.data.updates.updatedCells);
+        return result;
+    } catch (err) {
+        throw err;
+    }
+}
+
+writeTestData()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@nprapps/google-login": "^1.0.2",
     "@slack/web-api": "^7.0.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "googleapis": "^134.0.0"
   }
 }


### PR DESCRIPTION
## Describe your changes
This PR adds the basic configuration to add sample data to Google Sheets. 

## Issue ticket number and link
This ticket is part of the issue [#165](https://github.com/nprapps/elections24-primaries/issues/165)

It is using my Google Sheet ID. Look into why it isn't working with Google Sheet created with `visualdev` account.

## Testing Steps

1. Run `npm i`
2. Run `node elex-testing-results/sheets.js`
3. **OPTIONAL**: Update values [here](https://github.com/nprapps/elections-bots/blob/gsheets/elex-testing-results/sheets.js#L10-L14)
4. Check Google [sheet](https://docs.google.com/spreadsheets/d/1LFtG54Bmzz_AptuHzdxFbQpH7DaWfvFoMog4WBBIa2k/edit#gid=0) with updated data.
