### PR TITLE
filter data

### DIFF
--- a/elex-testing-results/getElexTestData.js
+++ b/elex-testing-results/getElexTestData.js
@@ -1,4 +1,6 @@
 var axios = require("axios");
+const { filterData } = require("./helpers/filterData");
+const { formatData } = require("./helpers/formatData");
 
 const URL =
   "https://api.ap.org/v3/reports/Calendar-CustomerTesting2024-Live?format=json";
@@ -13,24 +15,14 @@ async function getElexTestData() {
       url: URL,
       headers,
     });
+
     const data = response.data;
     const lastUpdatedDate = data[calendarYear].lastUpdate.lastUpdated;
     const testData = data[calendarYear].TestInformation;
-    const elexTestData = [];
+    const filteredData = await filterData(testData);
+    const formattedTestData = formatData(filteredData);
 
-    //! Here we will create a function to filter the data.
-
-    //* Format data for google sheets
-    testData.map((data) => {
-      elexTestData.push([
-        data.testDate,
-        data.electionEvents,
-        data.activity,
-        data.testTimeET ? data.testTimeET : false,
-      ]);
-    });
-
-    return { lastUpdatedDate, elexTestData };
+    return { lastUpdatedDate, formattedTestData };
   } catch (error) {
     console.error(error);
   }

--- a/elex-testing-results/helpers/filterData.js
+++ b/elex-testing-results/helpers/filterData.js
@@ -1,0 +1,11 @@
+async function filterData(testData) {
+  const yesterdaysDate = new Date(new Date().setDate(new Date().getDate() - 1));
+
+  return testData.filter(
+    (data) => new Date(`${data.testDate}T00:00`) > yesterdaysDate
+  );
+}
+
+module.exports = {
+  filterData,
+};

--- a/elex-testing-results/helpers/formatData.js
+++ b/elex-testing-results/helpers/formatData.js
@@ -1,0 +1,18 @@
+function formatData(filteredData) {
+  const elexTestData = [];
+
+  filteredData.map((data) => {
+    elexTestData.push([
+      data.testDate,
+      data.electionEvents,
+      data.activity,
+      data.testTimeET ? data.testTimeET : false,
+    ]);
+  });
+
+  return elexTestData;
+}
+
+module.exports = {
+  formatData,
+};

--- a/elex-testing-results/index.js
+++ b/elex-testing-results/index.js
@@ -8,11 +8,10 @@ const { getElexTestData } = require("./getElexTestData");
   //! This is confusing as hell, make it clearer
   if (!isSheetEmpty) {
     //* The sheet is empty
-
     const data = await getElexTestData();
 
     const lastUpdatedDate = data.lastUpdatedDate;
-    const elexTestData = data.elexTestData;
+    const elexTestData = data.formattedTestData;
 
     await writeDataToSheets(lastUpdatedDate, elexTestData);
   } else {


### PR DESCRIPTION
## Describe your changes

This PR adds a function that filters old data and adds only upcoming testing data to the sheets.
Also, refactored the `getElexData` file a bit.

## Issue ticket number and link

[#167](https://github.com/nprapps/elections24-primaries/issues/167)

## Testing Steps

- Make sure to delete the election [sheet](https://docs.google.com/spreadsheets/d/11NMkh8GqUYRCHKMKuPu9bGsS7G1sSbMaDk0YaLxNdSI/edit#gid=0).
- Rerun this GitHub [action](https://github.com/nprapps/elections-bots/actions/runs/8788687242) to see if this works.
