### PR TITLE
updated the cron job to run at minute 25 and 55

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: AP Testing Calendar
 
 on: 
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "25,55 * * * *"
     
 jobs:
   build-node:


### PR DESCRIPTION
## Describe your changes

This PR updates the cron job to run at minutes 25 and 55. [Crontab Guru](https://crontab.guru/#25,55_*_*_*_*) for the win.

According to the [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule):

> The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. High load times include the start of every hour. If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour. 

## Issue ticket number and link

[#169](https://github.com/nprapps/elections24-primaries/issues/169)

## Testing Steps
Make sure to delete everything from the [sheets](https://docs.google.com/spreadsheets/d/11NMkh8GqUYRCHKMKuPu9bGsS7G1sSbMaDk0YaLxNdSI/edit#gid=0) before the 25 or 55 minute, and then see the magic happen.

