### PR TITLE
formatted slack message depending on the type

### DIFF
--- a/elex-testing-results/helpers/compareTime.js
+++ b/elex-testing-results/helpers/compareTime.js
@@ -21,7 +21,7 @@ async function compareTime(elexTestData) {
         "2024-04-26",
         "NY CD 26 Special Election",
         "Customer Testing",
-        "2:00 pm-7:30 pm",
+        "4:30 pm-7:30 pm",
       ],
       [
         "2024-04-26",
@@ -50,9 +50,7 @@ async function compareTime(elexTestData) {
     const date = data[0];
     const time = data[3];
 
-    console.log({ time });
     if (time) {
-      //! don't hard code pm value
       const timePeriod = time.split("-")[0].slice(-2);
       const startTestingTime = `${time.slice(0, 5)} ${timePeriod}`;
 

--- a/elex-testing-results/slack/sendMessageToSlack.js
+++ b/elex-testing-results/slack/sendMessageToSlack.js
@@ -5,20 +5,24 @@ require("dotenv").config();
 const channelID = "C06TYKYGGM9";
 const web = new WebClient(process.env.SLACK_TOKEN);
 
-async function sendMessageToSlack(data) {
-  console.log({ data });
-  //! test should be singular if there is only one test for the day
-  let scheduledText = `Today's upcoming tests: \n`;
+async function sendMessageToSlack(data, type) {
+  let scheduledText = `Today's upcoming ${data.length ? "tests" : "test"}: \n`;
+  let intervalMessage = "";
 
-  //! if there is no data for the day, don't send a message
   data.map((text) => {
     scheduledText += `- *${text[2]}* - ${text[1]} ${text[3] ? text[3] : ""} \n`;
+  });
+
+  data.map((text) => {
+    intervalMessage += `AP: ${text[2]} ${
+      text[2] === "Election Day" ? "" : "begins now"
+    } - ${text[1]} ${text[3] ? text[3] : ""} \n`;
   });
 
   try {
     await web.chat.postMessage({
       channel: channelID,
-      text: scheduledText,
+      text: type === "scheduleMessage" ? scheduledText : intervalMessage,
     });
 
     console.log("Message has been posted");

--- a/elex-testing-results/slack/sendSchedule.js
+++ b/elex-testing-results/slack/sendSchedule.js
@@ -8,7 +8,7 @@ async function sendSchedule() {
   const data = getTodaysTests(elexData);
 
   if (data.length) {
-    await sendMessageToSlack(data);
+    await sendMessageToSlack(data, "scheduleMessage");
   }
 }
 


### PR DESCRIPTION
## Describe your changes
This PR formats the slack message. If it's sending a message in the morning about upcoming tests, the format will look like this:
```
Today's upcoming tests:
- Customer Testing - PR Dem Presidential Primary 12:00 pm-1:00 pm
- Customer Testing - NY CD 26 Special Election 1:30 pm-2:30 pm
- Customer Testing - IN Presidential/State Primary 3:00 pm-4:00 pm
- Customer Testing - MD NE NC WV Presidential/State Primaries 4:30 pm-5:30 pm
```

Else, it will look like this:
```
AP: Customer Testing begins now — PA Presidential/State Primary (4:30pm-5:30pm)
```

## Issue ticket number and link
[#168](https://github.com/nprapps/elections24-primaries/issues/168)

## Testing Steps
Check #elex-bots-test channel for the format. 
