### PR TITLE
updated slack message format and fixed the bug:

### DIFF
--- a/elex-tabulation-data/sheets/compareAndUpdateData.js
+++ b/elex-tabulation-data/sheets/compareAndUpdateData.js
@@ -55,7 +55,9 @@ async function compareAndUpdateData(dataFromSheets, elexData) {
         }
       }
     } else {
-      updatedData.push(curVal);
+      if (!ids.includes(uniqueID)) {
+        updatedData.push(curVal);
+      }
     }
   });
 

--- a/elex-tabulation-data/sheets/writeElexDataToSheets.js
+++ b/elex-tabulation-data/sheets/writeElexDataToSheets.js
@@ -15,7 +15,7 @@ async function writeElexDataToSheets(values) {
     credentials: GOOGLE_CREDENTIALS,
     scopes: ["https://www.googleapis.com/auth/spreadsheets"],
   });
-  const valueInputOption = "USER_ENTERED";
+  const valueInputOption = "RAW";
 
   const sheets = google.sheets({ version: "v4", auth: client });
 

--- a/elex-tabulation-data/slack/sendMessageToSlack.js
+++ b/elex-tabulation-data/slack/sendMessageToSlack.js
@@ -1,13 +1,32 @@
 const { WebClient } = require("@slack/web-api");
 require("dotenv").config();
 
-const channelID = "C06TYKYGGM9";
-const web = new WebClient(process.env.SLACK_TOKEN);
+/**
+ * 
+ * @param {[{}]} data 
+//   [{
+//   uniqueID: '6243-6',
+//   electionDate: '2024-06-25',
+//   officeID: 'H',
+//   officeName: 'U.S. House',
+//   stateID: '6',
+//   seatName: 'District 4',
+//   seatNum: '4',
+//   stateName: 'Colorado',
+//   raceID: '6243',
+//   raceType: 'Primary',
+//   tabulationStatus: 'Awaiting Poll Close',
+//   raceCallStatus: 'Too Early to Call'
+// }];
+ */
 
 async function sendMessageToSlack(data) {
+  const channelID = "C06TYKYGGM9";
+  const web = new WebClient(process.env.SLACK_TOKEN);
+
   let message = "Tabulation status for following races have changed: \n";
   data.map((text) => {
-    message += `- ${text.officeID} - ${text.stateName}: *${text.tabulationStatus}*  \n`;
+    message += `- ${text.stateName}'s ${text.officeName} race for ${text.seatName}: Tabulation Status is *${text.tabulationStatus}* and Race Call status is *${text.raceCallStatus}*  \n`;
   });
 
   try {
@@ -23,21 +42,6 @@ async function sendMessageToSlack(data) {
     console.error(error);
   }
 }
-
-// sendMessageToSlack([
-//   {
-//     uniqueID: "41902-41",
-//     electionDate: undefined,
-//     officeID: "H",
-//     stateID: "41",
-//     seatName: "",
-//     seatNum: "",
-//     stateName: undefined,
-//     raceID: "41902",
-//     tabulationStatus: "Active Tabulation",
-//     raceCallStatus: "Too Early to Call",
-//   },
-// ]);
 
 module.exports = {
   sendMessageToSlack,

--- a/helpers/filterByRace.js
+++ b/helpers/filterByRace.js
@@ -1,9 +1,0 @@
-function filterByRace(raceData) {
-  return raceData.filter(
-    (data) =>
-      data.officeID === "P" || data.officeID === "S" || data.officeID === "H"
-  );
-}
-module.exports = {
-  filterByRace,
-};

--- a/helpers/formatElexData.js
+++ b/helpers/formatElexData.js
@@ -8,6 +8,7 @@ function formatElexData(elexData) {
       uniqueID: `${race.raceID}-${race.stateID}`,
       electionDate: electionDate,
       officeID: race.officeID,
+      officeName: race.officeName,
       stateID: race.stateID,
       seatName: race.seatName,
       seatNum: race.seatNum,


### PR DESCRIPTION
## Describe your changes

- This PR updates the Slack format message.
- This PR also fixes the bug where it would add a duplicate value.
- I also noticed that using `USER_ENTERED` as the value for `valueInputOption` changed the uniqueID to a date format because, according to the [docs](https://developers.google.com/sheets/api/reference/rest/v4/ValueInputOption), 'user_entered' will parse the values as if the user typed them into the UI. I updated it to `RAW`, which does not parse the values and will store them as-is.

## Issue ticket number and link

[#24](https://github.com/nprapps/elections-bots/issues/24)

## Testing Steps

Run the corn job to see the changes in the spreadsheet and a message in the slack channel.
